### PR TITLE
upd: enable Angular Universal (SSR) compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This package is a fork from [https://github.com/jelgblad/angular2-masonry](https://github.com/jelgblad/angular2-masonry) to update it to work for newer Angular releases as no work seems to have been done on it for almost 12 months (at the time of writing this). **If** I have the time, I will look into further improvements. I can't guarantee any help.
 
+This updated version is also compatible with Angular Universal server side rendering (SSR)
+
 [![npm version](https://badge.fury.io/js/ngx-masonry.svg)](https://www.npmjs.com/package/ngx-masonry)
 
 > ngx-masonry is in development and **not ready for production use**.

--- a/README.md
+++ b/README.md
@@ -59,14 +59,7 @@ import { NgxMasonryModule } from 'ngx-masonry';
    ]
  }
  ```
- 
- You will also need to add this css to your parent stylesheet for the masonry layout to work correctly:
-```
-ngx-masonry {
-  display: block !important;
-}
-```
- 
+  
 ## Configuration
 
 ### Options

--- a/src/ngx-masonry.component.ts
+++ b/src/ngx-masonry.component.ts
@@ -5,13 +5,19 @@ import {
 	Input,
 	Output,
 	ElementRef,
-	EventEmitter
+	EventEmitter,
+	PLATFORM_ID,
+	Inject,
 } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 
 declare var require: any;
 declare var imagesLoaded: any;
 
-var masonry = require('masonry-layout');
+if (!(typeof process === 'object' && process + '' === '[object process]')) {
+	// is browser
+  var Masonry = require('masonry-layout');
+}
 
 import { NgxMasonryOptions } from './ngx-masonry-options.interface';
 
@@ -20,8 +26,10 @@ import { NgxMasonryOptions } from './ngx-masonry-options.interface';
 	template: '<ng-content></ng-content>'
 })
 export class NgxMasonryComponent implements OnInit, OnDestroy {
-	constructor(private _element: ElementRef) {}
-
+	constructor(
+		@Inject(PLATFORM_ID) private platformId: any,
+		private _element: ElementRef) {}
+	
 	public _msnry: any;
 	private _imagesLoaded = null;
 
@@ -47,23 +55,20 @@ export class NgxMasonryComponent implements OnInit, OnDestroy {
 			this.options.itemSelector = '[ngx-masonry-item], ngx-masonry-item';
 		}
 
-		// Set element display to block
-		if (this._element.nativeElement.tagName === 'MASONRY') {
-			this._element.nativeElement.style.display = 'block';
+		if (isPlatformBrowser(this.platformId)) {			
+			// Initialize Masonry
+			this._msnry = new Masonry(this._element.nativeElement, this.options);
+
+			// console.log('AngularMasonry:', 'Initialized');
+
+			// Bind to events
+			this._msnry.on('layoutComplete', (items: any) => {
+				this.layoutComplete.emit(items);
+			});
+			this._msnry.on('removeComplete', (items: any) => {
+				this.removeComplete.emit(items);
+			});
 		}
-
-		// Initialize Masonry
-		this._msnry = new masonry(this._element.nativeElement, this.options);
-
-		// console.log('AngularMasonry:', 'Initialized');
-
-		// Bind to events
-		this._msnry.on('layoutComplete', (items: any) => {
-			this.layoutComplete.emit(items);
-		});
-		this._msnry.on('removeComplete', (items: any) => {
-			this.removeComplete.emit(items);
-		});
 	}
 
 	ngOnDestroy() {
@@ -119,6 +124,6 @@ export class NgxMasonryComponent implements OnInit, OnDestroy {
 		// Layout items
 		this.layout();
 
-		console.log('AngularMasonry:', 'Brick removed');
+		// console.log('AngularMasonry:', 'Brick removed');
 	}
 }

--- a/src/ngx-masonry.directive.ts
+++ b/src/ngx-masonry.directive.ts
@@ -4,10 +4,12 @@ import {
 	ElementRef,
 	forwardRef,
 	OnDestroy,
-	AfterViewInit
+	AfterViewInit,
+	PLATFORM_ID,	
 } from '@angular/core';
 
 import { NgxMasonryComponent } from './ngx-masonry.component';
+import { isPlatformBrowser } from '@angular/common';
 
 interface MutationWindow extends Window {
 	MutationObserver: any;
@@ -23,16 +25,21 @@ export class NgxMasonryDirective implements OnDestroy, AfterViewInit {
 	constructor(
 		private _element: ElementRef,
 		@Inject(forwardRef(() => NgxMasonryComponent))
-		private _parent: NgxMasonryComponent
+		private _parent: NgxMasonryComponent,
+		@Inject(PLATFORM_ID) private platformId: any,		
 	) {}
 
 	ngAfterViewInit() {
-		this._parent.add(this._element.nativeElement);
-		this.watchForHtmlChanges();
+		if (isPlatformBrowser(this.platformId)) {
+			this._parent.add(this._element.nativeElement);
+			this.watchForHtmlChanges();			
+		}
 	}
 
 	ngOnDestroy() {
-		this._parent.remove(this._element.nativeElement);
+		if (isPlatformBrowser(this.platformId)) {
+			this._parent.remove(this._element.nativeElement);
+		}
 	}
 
 	/** When HTML in brick changes dinamically, observe that and change layout */


### PR DESCRIPTION
This PR makes `ngx-masonry` compatible with Angular Universal server side rendering. I was sort of flying by the seat of my pants as I did this, but everything seems to be working on my end. Note, I haven't tested this with the `imagesloaded` package. That `require` may need an additional `isPlatformBrowser` wrapping. This being said, I looked at the `imagesloaded` code and it appears to already contain an `typeof window === 'undefined' ?` test.

My general strategy is to delay initialization of Masonry until it's loaded in the browser. I also updated the `<ngx-masonry>` component so that it automatically has a `display: block` style associated with it. 

Note, this PR does nothing to address the other issue I reported (#1).