### PR TITLE
Fix issue #52 with null images property within an item

### DIFF
--- a/src/lib/ngx-masonry.component.ts
+++ b/src/lib/ngx-masonry.component.ts
@@ -114,7 +114,7 @@ export class NgxMasonryComponent implements OnInit, OnChanges, OnDestroy {
     if (this.ordered) {
       for (const [index, item] of this.pendingItems.entries()) {
         if (item) {
-          if (item.images.size === 0) {
+          if (item.images && item.images.size === 0) {
             this.pendingItems[index] = undefined;
             this.itemLoaded(item);
             if (index + 1 === this.pendingItems.length) {


### PR DESCRIPTION
This PR will fix #52.

There was a missing check when using `item.images` inside the `@add()` method.