### PR TITLE
Fix issue #51: Angular universal - TypeError: object is not iterable

### DIFF
--- a/src/lib/ngx-masonry.directive.ts
+++ b/src/lib/ngx-masonry.directive.ts
@@ -39,7 +39,7 @@ export class NgxMasonryDirective implements OnInit, OnDestroy, AfterViewInit {
   }
 
   ngAfterViewInit() {
-    const images = this.element.nativeElement.getElementsByTagName('img');
+    const images = Array.from(this.element.nativeElement.getElementsByTagName('img'));
     if (images.length === 0) {
       setTimeout(() => {
         this.parent.add(this);


### PR DESCRIPTION
As proposed by @ziunio, this PR should fix #51.

HTMLCollectionOf is not iterable in TypeScript, therefore it is converted into an array.