### PR TITLE
Fixes empty space created, when adding hardcoded elements in HTML

### DIFF
--- a/src/lib/ngx-masonry.directive.ts
+++ b/src/lib/ngx-masonry.directive.ts
@@ -9,6 +9,7 @@ import { NgxMasonryAnimations } from './ngx-masonry-options';
 })
 export class NgxMasonryDirective implements OnInit, OnDestroy, AfterViewInit {
   @Input() prepend = false;
+  @Input() ready = false;
 
   public images: Set<HTMLImageElement>;
   private animations: NgxMasonryAnimations = {
@@ -35,28 +36,33 @@ export class NgxMasonryDirective implements OnInit, OnDestroy, AfterViewInit {
     }
     this.renderer.setStyle(this.element.nativeElement, 'position', 'fixed');
     this.renderer.setStyle(this.element.nativeElement, 'right', '-150vw');
-    this.parent.addPendingItem(this);
+
+    if (!this.ready) {
+      this.parent.addPendingItem(this);
+    }
   }
 
   ngAfterViewInit() {
-    const images: HTMLImageElement[] = Array.from(this.element.nativeElement.getElementsByTagName('img'));
-    this.images = new Set(images);
-    if (images.length === 0) {
-      setTimeout(() => {
-        this.parent.add(this);
-      });
-    } else {
-      for (const imageRef of images) {
-        // skip image render check if image has `masonryLazy` attribute
-        if (imageRef.hasAttribute('masonryLazy')) {
-            this.imageLoaded(imageRef);
-        } else { 
-          this.renderer.listen(imageRef, 'load', _ => {
-            this.imageLoaded(imageRef);
-          });
-          this.renderer.listen(imageRef, 'error', _ => {
-            this.imageLoaded(imageRef);
-          });
+    if (!this.ready) {
+      const images: HTMLImageElement[] = Array.from(this.element.nativeElement.getElementsByTagName('img'));
+      this.images = new Set(images);
+      if (images.length === 0) {
+        setTimeout(() => {
+          this.parent.add(this);
+        });
+      } else {
+        for (const imageRef of images) {
+          // skip image render check if image has `masonryLazy` attribute
+          if (imageRef.hasAttribute('masonryLazy')) {
+              this.imageLoaded(imageRef);
+          } else { 
+            this.renderer.listen(imageRef, 'load', _ => {
+              this.imageLoaded(imageRef);
+            });
+            this.renderer.listen(imageRef, 'error', _ => {
+              this.imageLoaded(imageRef);
+            });
+          }
         }
       }
     }


### PR DESCRIPTION
I am proposing this as a solution to the comments in #50 after it was closed.

This is needed, since hardcoded elements for ngxMasonry are added to the `pendingItems` even though they are already visible. This means that for every hardcoded element, an empty space of the same size will be added to the ngxMasonry. This means you get an empty space in the top proportional to the number of hardcoded elements.
Since I don't know of any automatic way to check whether a directive/element was hardcoded or added by an ngFor or ngIf, my solution is to simply add an input to the ngxMasonryDirective, that by default continues to work as normal, but for anyone (including myself) who needs hardcoded elements, they can set the input parameter `ready`, which prevents that particular ngxMasonryDirective from being added to the `pendingItems`.
Therefore by setting `ready="true"` it is regarded as "ready" and therefore is not pending, but not setting it will not change anything for current uses.